### PR TITLE
Parameterize output filename with `config.approach`.

### DIFF
--- a/src/sal/utils/data.py
+++ b/src/sal/utils/data.py
@@ -72,5 +72,5 @@ def save_dataset(dataset, config):
         if config.output_dir is None:
             config.output_dir = f"data/{config.model_path}"
         Path(config.output_dir).mkdir(parents=True, exist_ok=True)
-        dataset.to_json(f"{config.output_dir}/bon_completions.jsonl", lines=True)
-        logger.info(f"Saved completions to {config.output_dir}/bon_completions.jsonl")
+        dataset.to_json(f"{config.output_dir}/{config.approach}_completions.jsonl", lines=True)
+        logger.info(f"Saved completions to {config.output_dir}/{config.approach}_completions.jsonl")


### PR DESCRIPTION
Previous code always outputs to `bon_completions.jsonl`, which clobbers the previous file. I am assuming "bon" is short for "best-of-n."

This PR parametrizes the filename with the approach to avoid clobbering existing logs.

Feel free to revise or reject.

Thanks.