### PR TITLE
Removed duplicated `aggregate_scores` function

### DIFF
--- a/src/sal/utils/math.py
+++ b/src/sal/utils/math.py
@@ -27,19 +27,6 @@ from sympy import latex, simplify
 from .qwen_math_parser import extract_answer, strip_string
 
 
-def aggregate_scores(
-    scores: list[float], agg_strategy: Literal["min", "prod", "last"]
-) -> float:
-    if agg_strategy == "min":
-        return min(scores)
-    elif agg_strategy == "prod":
-        return math.prod(scores)
-    elif agg_strategy == "last":
-        return scores[-1]
-    else:
-        raise ValueError(f"Invalid aggregation strategy: {agg_strategy}")
-
-
 # Timeout exception
 class TimeoutException(Exception):
     pass

--- a/src/sal/utils/score.py
+++ b/src/sal/utils/score.py
@@ -22,7 +22,6 @@ from tqdm import tqdm
 
 from sal.config import Config
 from sal.utils.math import (
-    aggregate_scores,
     compute_maj_pred,
     compute_naive_pred,
     compute_weighted_pred,


### PR DESCRIPTION
fix #27

As mentioned in the issue, the `aggregate_scores` function in `scores.py` is both imported from `sal.utils.math` and redefined within the same file. Additionally, in the various search strategies, it is imported from `sal.utils.score`. This suggests that the function has a duplicated definition, which can lead to inconsistencies. 😊

@lewtun 