### PR TITLE
Support for Qwen2.5-Math-PRM-7B model

### DIFF
--- a/recipes/AceMath-7B-Instruct/beam_search.yaml
+++ b/recipes/AceMath-7B-Instruct/beam_search.yaml
@@ -1,0 +1,11 @@
+# refer to src/sal/config.py for more options
+
+model_path: nvidia/AceMath-7B-Instruct
+prm_path: Qwen/Qwen2.5-Math-PRM-7B
+custom_chat_template: null
+filter_duplicates: true
+approach: beam_search
+n: 4
+search_batch_size: 1  # DO NOT CHANGE!
+num_samples: 10       # REMOVE THIS LINE TO RUN ON THE WHOLE DATASET
+seed: 0

--- a/recipes/AceMath-7B-Instruct/best_of_n.yaml
+++ b/recipes/AceMath-7B-Instruct/best_of_n.yaml
@@ -1,0 +1,12 @@
+# refer to src/sal/config.py for more options
+
+model_path: nvidia/AceMath-7B-Instruct
+prm_path: Qwen/Qwen2.5-Math-PRM-7B
+custom_chat_template: null
+approach: best_of_n
+n: 4
+search_batch_size: 25
+sort_completed: true
+filter_duplicates: true
+num_samples: 10         # REMOVE THIS LINE TO RUN ON THE WHOLE DATASET
+seed: 0

--- a/recipes/AceMath-7B-Instruct/dvts.yaml
+++ b/recipes/AceMath-7B-Instruct/dvts.yaml
@@ -1,0 +1,10 @@
+# refer to src/sal/config.py for more options
+
+model_path: nvidia/AceMath-7B-Instruct
+prm_path: Qwen/Qwen2.5-Math-PRM-7B
+custom_chat_template: null
+approach: dvts
+n: 4
+search_batch_size: 25
+num_samples: 10       # REMOVE THIS LINE TO RUN ON THE WHOLE DATASET
+seed: 0


### PR DESCRIPTION
I have added support for the Qwen-2.5-Math-PRM-7B model and included sample recipes for its use. These recipes utilize the nvidia/AceMath-7B-Instruct model as the Policy model, as it is a fine-tuned version of Qwen/Qwen-2.5-Math-7B-Instruct by NVIDIA, demonstrating superior performance across various math benchmarks. 
